### PR TITLE
integrated max_completion_depth limit for recursion limit

### DIFF
--- a/run.py
+++ b/run.py
@@ -10,7 +10,11 @@ from common import limit_depth
 
 montecarlo = MonteCarlo(Node(prompt))
 
-def generate_complete(text, montecarlo):
+max_completion_depth = 30
+
+def generate_complete(text, montecarlo, current_completion_depth=1):
+    if current_completion_depth >= max_completion_depth:
+        return None
     text = llm.generate(text, 1)[0]
     score = score_func(text)
     if score is not None:
@@ -21,7 +25,7 @@ def generate_complete(text, montecarlo):
                 montecarlo.solution = text
             return text
     else:
-        return generate_complete(text, montecarlo)
+        return generate_complete(text, montecarlo, current_completion_depth + 1)
 
 
 def child_finder(node, montecarlo):


### PR DESCRIPTION
Added a global recursion limit for the `generate_complete` function to avoid getting stuck in an infinite recursive loop in case `score` keeps getting assigned a value of `None`