### PR TITLE
Improve lean4 prompt

### DIFF
--- a/prompts.py
+++ b/prompts.py
@@ -28,7 +28,7 @@ problem_fact = (f"""### Spec: In {lang}, write a factorial function and prove th
 ### Hint: use `Nat.lt_0_1` in the base case of the proof.
 ### Hint: use `Nat.lt_lt_add_r` in the inductive case of the proof.
 ''' if lang=='Coq' else ''
-}### {lang}:""",
+}""",
                 500, None, 5, 15, check_proof, all_langs)
 problem_opt0 = (f"""### Spec: In {lang}, write an ADT for arithmetic expressions comprising constants, variables and binary addition. Then write an evaluator taking an expression and an environment (a function that takes a variable name and returns a number) and returns the number resulting from evaluation. Then write an optimizer tha takes an expression and returns an expression with all additions by 0 removed. Then prove that the optimizer preserves the semantics as defined by the evaluation function.
 {'''### Hint: Recall that in Dafny, pattern match takes the form
@@ -46,7 +46,7 @@ case _ => 3
 ### Hint: For the inductive case of the proof, `eauto using PeanoNat.Nat.add_0_r` might be useful (`Require Arith` in the imports).
 ### Hint: You can also rewrite backwards: `rewrite <- H`.
 ''' if lang=='Coq' else ''
-}### {lang}:""",### {lang}:""",
+}""",
                 1000, None, 22, 40, check_proof, all_langs)
 
 problem_max_dafny = ("""
@@ -135,7 +135,7 @@ Insert a number 'delimeter' between every two consecutive elements of input list
 """, 1000, None, 5, 20, check_proof, ['Dafny'])
 
 # Set the right-hand side to the selected problem.
-(prompt, max_new_tokens, expansion_count, min_lines, max_depth, check_fun, supported_langs) = problem_opt0
+(prompt, max_new_tokens, expansion_count, min_lines, max_depth, check_fun, supported_langs) = problem_fact
 
 def remove_hints(prompt):
     lines = prompt.split('\n')
@@ -145,14 +145,17 @@ def remove_hints(prompt):
 #prompt = remove_hints(prompt)
 
 assert lang in supported_langs
+
 if lang != 'Lean4':
-    prompt = '''
-Put your code in triple quotes:
-```
+    prompt = f'''
+Put your {lang} code in triple quotes:
+```{lang}
 ```
 ''' + prompt
-if lang == 'Lean4':
+elif lang == 'Lean4':
     prompt += '''
-```lean
+Import mathlib4 whenever necessary:
+```lean4
 import Mathlib
+```
 '''


### PR DESCRIPTION
- Fixes a bug with parsing at end of lean4 prompt caused by missing ```
- Attempt to guide generation of lean4 (than lean3)
- Removes redundant instructions (### {lang}:)