### PR TITLE
add run_diversity, return hiddens from llm

### DIFF
--- a/llm.py
+++ b/llm.py
@@ -4,7 +4,7 @@ from typing import List
 if MODEL_HOST == "openai":
     import openai_generate
 
-    def generate(promptL: str, num: str) -> List[str]:
+    def generate(prompt: str, num: str) -> List[str]:
         return openai_generate.generate(prompt, num)
 
 elif MODEL_HOST == "huggingface":
@@ -12,21 +12,31 @@ elif MODEL_HOST == "huggingface":
     import huggingface_generate
 
     _, model, tokenizer = huggingface_generate.load_model()
-    model_generation_args = huggingface_generate.get_model_generation_args(tokenizer)  # todo: types
+    model_generation_args = huggingface_generate.get_model_generation_args(
+        tokenizer
+    )  # todo: types
 
-    def gen(prompt, model_generation_args, num=1) -> List[str]:
+    def gen(prompt, model_generation_args, num=1, return_hiddens=False) -> List[str]:
         num = num or 1
         model_input = tokenizer(prompt, return_tensors="pt").to("cuda")
         model.eval()
         with torch.no_grad():
-            ts = model.generate(
-                **model_input, num_return_sequences=num, **model_generation_args
+            generate_dict = model.generate(
+                **model_input,
+                num_return_sequences=num,
+                output_hidden_states=return_hiddens,
+                return_dict_in_generate=True,
+                **model_generation_args
             )
+            ts = generate_dict.sequences
             rs = [tokenizer.decode(t, skip_special_tokens=True) for t in ts]
+        if return_hiddens:
+            last_layer = generate_dict.hidden_states[-1][-1][:, -1, :]
+            return rs, last_layer.reshape(num, -1)
         return rs
 
-    def generate(prompt: str, num: str) -> List[str]:
-        return gen(prompt, model_generation_args, num)
+    def generate(prompt: str, num: str, return_hiddens=False) -> List[str]:
+        return gen(prompt, model_generation_args, num, return_hiddens)
 
 else:
     assert False

--- a/montecarlo/montecarlo.py
+++ b/montecarlo/montecarlo.py
@@ -8,6 +8,8 @@ class MonteCarlo:
         self.child_finder = None
         self.node_evaluator = lambda child, montecarlo: None
 
+        self.global_features = None
+
     def make_choice(self):
         best_children = []
         most_visits = float("-inf")
@@ -42,7 +44,7 @@ class MonteCarlo:
 
             if self.solution is not None:
                 return
-            
+
             current_node = self.root_node
 
             while current_node.expanded:

--- a/run_diversity.py
+++ b/run_diversity.py
@@ -1,0 +1,89 @@
+import torch
+import llm
+
+from montecarlo.node import Node
+from montecarlo.montecarlo import MonteCarlo
+
+from lang import score_func, can_be_solution
+
+from prompts import prompt, expansion_count, min_lines, check_func
+from common import limit_depth, max_completion_depth
+
+montecarlo = MonteCarlo(Node(prompt))
+
+
+def add_features(features, montecarlo):
+    assert len(features.shape) == 1
+    reshape_features = features.unsqueeze(0).to(torch.float32)
+    if montecarlo.global_features is None:
+        montecarlo.global_features = reshape_features
+    else:
+        montecarlo.global_features = torch.cat(
+            (montecarlo.global_features, reshape_features), dim=0
+        )
+
+
+def select_diversely(text, features, montecarlo):
+    """
+    Selects the text that is most different from the global features
+    """
+    assert len(features.shape) == 2
+    if montecarlo.global_features is None:
+        idx = 0
+    else:
+        all_distances = torch.zeros((len(features), len(montecarlo.global_features)))
+        for i, feature in enumerate(features):
+            for j, global_feature in enumerate(montecarlo.global_features):
+                # TODO: using L2 distance here, maybe try cosine distance?
+                all_distances[i][j] = torch.dist(feature, global_feature)
+
+        dist_to_closest = torch.min(all_distances, dim=1)[0]  # dim: b
+        idx = torch.argmax(dist_to_closest)
+
+    add_features(features[idx], montecarlo)
+    return text[idx]
+
+
+def generate_complete(text, montecarlo, current_completion_depth=1):
+    if current_completion_depth >= max_completion_depth:
+        return None
+    text, features = llm.generate(text, 3, return_hiddens=True)
+    text = select_diversely(text, features, montecarlo)
+    # TODO: try to select features after scoring instead? It's unclear exactly how to do this.
+
+    score = score_func(text)
+    if score is not None:
+        if score < 0:
+            return None
+        else:
+            if can_be_solution(text, min_lines, check_func):
+                montecarlo.solution = text
+            return text
+    else:
+        return generate_complete(text, montecarlo, current_completion_depth + 1)
+
+
+def child_finder(node, montecarlo):
+    if limit_depth(node):
+        return
+
+    text = generate_complete(node.state, montecarlo)
+    if text is None:
+        node.update_win_value(-1)
+    else:
+        child = Node(text)
+        node.add_child(child)
+        child.update_win_value(1)
+        child.update_policy_value(1)
+
+        child = Node(node.state)
+        node.add_child(child)
+        child.update_policy_value(0.2)
+
+
+montecarlo.child_finder = child_finder
+
+montecarlo.simulate(expansion_count)
+
+print("CHOSEN SOLUTION")
+print(montecarlo.solution)


### PR DESCRIPTION
Added run_diversity.py to run search with actions selected to maximize distance from embeddings of previously seen actions. 

This required modifying llm.py to add an option to return hiddens when generating (False by default) and montecarlo.py to store the global features in the montecarlo object.

Also fixed a typo I noticed in llm.py where "prompt" was misspelled. 