### PR TITLE
Implement token limit

### DIFF
--- a/cmdline.py
+++ b/cmdline.py
@@ -37,6 +37,7 @@ class CommonArguments:
     experiment_name: str = field(default="run.py", metadata={"help": "Pick an experiment to run "})
     mins_timeout: float = field(default=None, metadata={"help": "Set a default timeout for each trial "})
     seed: int = field(default=None, metadata={"help": "Set the seed for reproducible behavior"})
+    token_limit: int = field(default=None, metadata={"help": "Max amount of tokens before execution is stopped"})
 
 
 def get_args():

--- a/llm.py
+++ b/llm.py
@@ -6,9 +6,10 @@ import sys
 token_counter = 0
 
 def handle_token_limit(new_tokens):
-    global token_counter
-    token_counter += new_tokens
     if args.token_limit is not None:
+        global token_counter
+        token_counter += new_tokens
+        print("generated", ntokens, "tokens, new count: ", token_counter, "/", args.token_limit)
         if token_counter > args.token_limit:
             print("Exceeded token limit.")
             print("Ending the generation prematurely.")
@@ -54,7 +55,6 @@ elif MODEL_HOST == "huggingface":
             ts = generate_dict.sequences
             ntokens = ts.size(0) * ts.size(1)
             handle_token_limit(ntokens)
-            print("generated", ntokens, "tokens")
             rs = [tokenizer.decode(t, skip_special_tokens=True) for t in ts]
         if return_hiddens:
             # Select features for last token by ignoring padding tokens

--- a/llm.py
+++ b/llm.py
@@ -35,6 +35,8 @@ elif MODEL_HOST == "huggingface":
                 **args
             )
             ts = generate_dict.sequences
+            ntokens = ts.size(0) * ts.size(1)
+            print("generated", ntokens, "tokens")
             rs = [tokenizer.decode(t, skip_special_tokens=True) for t in ts]
         if return_hiddens:
             # Select features for last token by ignoring padding tokens
@@ -69,10 +71,9 @@ elif MODEL_HOST == "huggingface":
         model.eval()
         r = None
         with torch.no_grad():
-            r = tokenizer.decode(model.generate(**model_input,
-                                                **all_args
-                                                )[0],
-                                 skip_special_tokens=True)
+            model_result = model.generate(**model_input, **all_args)
+            ntokens = ts.sequences.size(0) * ts.sequences.size(1)
+            r = tokenizer.decode(model_result[0], skip_special_tokens=True)
         return r
     
 else:

--- a/llm.py
+++ b/llm.py
@@ -9,7 +9,7 @@ def handle_token_limit(new_tokens):
     if args.token_limit is not None:
         global token_counter
         token_counter += new_tokens
-        print("generated", ntokens, "tokens, new count: ", token_counter, "/", args.token_limit)
+        print("generated", new_tokens, "tokens, new count: ", token_counter, "/", args.token_limit)
         if token_counter > args.token_limit:
             print("Exceeded token limit.")
             print("Ending the generation prematurely.")


### PR DESCRIPTION
Example: ./run.py --token-limit=1000

Note that this currently (very naively) counts the raw amount of tokens, including special tokens, padding tokens, etc, which inflates the absolute number of tokens. Not sure if this is a good idea.