### PR TITLE
add workaround for StarCoder

### DIFF
--- a/cmdline.py
+++ b/cmdline.py
@@ -45,6 +45,7 @@ class CommonArguments:
     wandb_project: str = field(default="vmcts", metadata={"help": "Project for the wandb run"})
     wandb_group: str = field(default="debug", metadata={"help": "Group for the wandb run"})
     wandb_name: str = field(default=None, metadata={"help": "Name the wandb run"})
+    stop_token_workaround: bool = field(default=False, metadata={"help": "Does not use the external library to impose stop token (this is a workaround for StarCoder)"})
 
     def dict(self):
         return {k: str(v) for k,v in asdict(self).items()}

--- a/cmdline.py
+++ b/cmdline.py
@@ -45,7 +45,6 @@ class CommonArguments:
     wandb_project: str = field(default="vmcts", metadata={"help": "Project for the wandb run"})
     wandb_group: str = field(default="debug", metadata={"help": "Group for the wandb run"})
     wandb_name: str = field(default=None, metadata={"help": "Name the wandb run"})
-    stop_token_workaround: bool = field(default=False, metadata={"help": "Does not use the external library to impose stop token (this is a workaround for StarCoder)"})
 
     def dict(self):
         return {k: str(v) for k,v in asdict(self).items()}

--- a/huggingface_generate.py
+++ b/huggingface_generate.py
@@ -15,6 +15,7 @@ from model_config import (
     MODEL_ARG_TEMP,
 )
 from typing import List, Tuple
+from cmdline import args
 
 
 def load_model(
@@ -54,9 +55,14 @@ def load_model(
 
 def stop_words_ids(tokenizer: AutoTokenizer) -> List[int]:
     # Hack: we want the stop word as it is encoded glued to another word.
-    stop_word_id = tokenizer.encode("hello" + STOP_WORD, add_special_tokens=False)[-1]
+    stop = tokenizer.encode("hello" + STOP_WORD, add_special_tokens=False)
+    stop_word_id = stop[-1]
+    assert(len(stop) == 2)
     quote_word_id = tokenizer.encode("```", add_special_tokens=False)[-1]
-    return [stop_word_id, quote_word_id]
+    if args.stop_token_workaround:
+        return [quote_word_id]
+    else:
+        return [stop_word_id, quote_word_id]
 
 
 def get_model_generation_token_args(

--- a/huggingface_generate.py
+++ b/huggingface_generate.py
@@ -1,5 +1,5 @@
 import torch
-from transformers import AutoModelForCausalLM, BitsAndBytesConfig, AutoTokenizer
+from transformers import AutoModelForCausalLM, BitsAndBytesConfig, AutoTokenizer, StoppingCriteria, StoppingCriteriaList
 from trl import AutoModelForCausalLMWithValueHead
 from peft import PeftModel
 from lang_config import STOP_WORD
@@ -16,6 +16,23 @@ from model_config import (
 )
 from typing import List, Tuple
 from cmdline import args
+
+class StopWordCriteria(StoppingCriteria):
+    def __init__(self, tokenizer, custom_stop, stop_word, l):
+        self.custom_stop = custom_stop
+        self.stop_word = stop_word
+        self.tokenizer = tokenizer
+        self.l = l
+
+    def __call__(self, input_ids, scores, **kwargs):
+        if not self.custom_stop:
+            return False
+        if input_ids.size(1) > self.l + 1:
+            for token_id in input_ids[0, self.l + 1:]:
+                token = self.tokenizer.decode(token_id)
+                if self.stop_word in token or "```" in token:
+                    return True
+        return False
 
 
 def load_model(
@@ -53,30 +70,18 @@ def load_model(
     return (base_model, model, tokenizer)
 
 
-def stop_words_ids(tokenizer: AutoTokenizer) -> List[int]:
-    # Hack: we want the stop word as it is encoded glued to another word.
-    stop = tokenizer.encode("hello" + STOP_WORD, add_special_tokens=False)
-    stop_word_id = stop[-1]
-    assert(len(stop) == 2)
-    quote_word_id = tokenizer.encode("```", add_special_tokens=False)[-1]
-    if args.stop_token_workaround:
-        return [quote_word_id]
-    else:
-        return [stop_word_id, quote_word_id]
-
-
 def get_model_generation_token_args(
     tokenizer: AutoTokenizer, custom_stop: bool = CUSTOM_STOP
 ):
     return dict(
         min_length=5,
         max_new_tokens=100,
-        eos_token_id=(
-            stop_words_ids(tokenizer) if custom_stop else tokenizer.eos_token_id
-        ),
+        eos_token_id=tokenizer.eos_token_id,
         pad_token_id=tokenizer.eos_token_id,
     )
 
+def get_stopping_criteria(tokenizer: AutoTokenizer, input_len):
+    return StoppingCriteriaList([StopWordCriteria(tokenizer, CUSTOM_STOP, STOP_WORD, input_len)]),
 
 def get_model_generation_search_args(num: int, beam_search: bool = BEAM_SEARCH):
     if beam_search:

--- a/llm.py
+++ b/llm.py
@@ -75,7 +75,7 @@ elif MODEL_HOST == "huggingface":
 
             def helper(tid):
                 return tid in tokenizer.all_special_ids
-            # This code needs uses the token count in two different contexts:
+            # This code uses the token count in two different contexts:
             # 1. for measuring the amount of generated tokens (as a proxy for time)
             # 2. (as a workaround for StarCoder) for knowing where the newly-generated
             # response begins (the model always returns both prompt and response).

--- a/llm.py
+++ b/llm.py
@@ -73,6 +73,11 @@ elif MODEL_HOST == "huggingface":
             )
             ts = generate_dict.sequences
 
+            def helper(tid):
+                return tid in tokenizer.all_special_ids
+            specialtok = sum(sum(helper(tid) for tid in t) for t in ts)
+            assert(specialtok < 2) # just to confirm there is no need to count special tok
+
             ntokens = ts.size(1) * ts.size(0)
             if args.stop_token_workaround:
                 tokens = [token for t in ts for token in t.tolist()]

--- a/llm.py
+++ b/llm.py
@@ -75,6 +75,17 @@ elif MODEL_HOST == "huggingface":
 
             def helper(tid):
                 return tid in tokenizer.all_special_ids
+            # This code needs uses the token count in two different contexts:
+            # 1. for measuring the amount of generated tokens (as a proxy for time)
+            # 2. (as a workaround for StarCoder) for knowing where the newly-generated
+            # response begins (the model always returns both prompt and response).
+            #
+            # For (1), we ideally do not want (too many) special tokens, especially
+            # no filler tokens.
+            # For (2), we need to count all tokens.
+            #
+            # As a compromise, this code assumes that there will be barely any special
+            # tokens, and checks this below.
             specialtok = sum(sum(helper(tid) for tid in t) for t in ts)
             assert(specialtok < 2) # just to confirm there is no need to count special tok
 


### PR DESCRIPTION
This adds a workaround to avoid the stop word issues with StarCoder 2 (and possibly other models).

Very ugly workaround unfortunately, that touches a few different files. Not super confident about this, it will need some more testing.

Usage example:
`python run_intermediate_expansion.py --base_model bigcode/starcoder2-15b --stop_token_workaround True`