### PR TITLE
Patch to handle EOS in limit_depth

### DIFF
--- a/common.py
+++ b/common.py
@@ -1,9 +1,9 @@
 from prompts import max_depth
+from llm import eos_token
+
 from cmdline import args
 
 max_completion_depth = args.max_completion_depth
-
-# max_completion_depth = 30
 
 
 def count_depth(node, f=lambda x: x):
@@ -18,10 +18,15 @@ def count_depth(node, f=lambda x: x):
     return depth
 
 
+# Prevents models from attempting to expand children past the EOS token
+def string_contains_eos(node, f=lambda x: x):
+    return eos_token in f(node.state)
+
+
 def limit_depth(node, f=lambda x: x):
     if max_depth is not None:
         depth = count_depth(node, f)
-        if depth >= max_depth:
+        if depth >= max_depth or string_contains_eos(node, f):
             node.update_win_value(-max_depth)
             return True
     return False


### PR DESCRIPTION
This patch handles EOS as if the model has hit the depth limit to prevent infinite expansions of the same string by attempting to generate after an EOS.

I changed the llm.py to (1) expose the eos_token and (2) set skip_special_tokens=False so that the EOS token will be added into the strings returned by gen().

Then in common.py, I check for eos_token at the same time as checking for max_depth, and prevent further expansion of this node is EOS has been reached.