### PR TITLE
Refactor language into common scoring framework

### DIFF
--- a/dafny.py
+++ b/dafny.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple, List
 from collections.abc import Callable
 
 def create_comment(msg: str) -> str:
-    return f"\n/* {msg} */\n"
+    return f"/* {msg} */"
 
 def calculate_code_score_with_err(v: str, code_maybe_incomplete: Callable[[int],bool]) -> (Optional[float], Optional[str]):
     if v == "":

--- a/lang.py
+++ b/lang.py
@@ -1,62 +1,12 @@
-from lang_config import LANG
-
-run_tests = False
-if LANG == "Dafny":
-    from dafny import (
-        score_func,
-        score_func_whole,
-        verifier_feedback,
-        short_verifier_feedback,
-        filter_code,
-        filter_code_whole,
-        check_code,
-    )
-elif LANG == "Coq":
-    from coq import (
-        score_func,
-        score_func_whole,
-        verifier_feedback,
-        short_verifier_feedback,
-        filter_code,
-        filter_code_whole,
-        check_code,
-    )
-elif LANG == "Lean4":
-    from lean import (
-        score_func,
-        verifier_feedback,
-        filter_code,
-        check_code,
-    )
-elif LANG == "Rust":
-    from rust import (
-        score_func,
-        verifier_feedback,
-        filter_code,
-        check_code,
-    )
-elif LANG == "Scala":
-    from scala import (
-        score_func,
-        verifier_feedback,
-        filter_code,
-        check_code,
-    )
-elif LANG == "Python":
-    from python import (
-        score_func,
-        score_func_whole,
-        verifier_feedback,
-        filter_code,
-        filter_code_whole,
-        check_code,
-        run_unittests,
-    )
-
-    run_tests = True
-else:
-    assert False
-
+from scoring import (
+    run_tests,
+    score_func,
+    score_func_whole,
+    short_verifier_feedback,
+    verifier_feedback,
+    filter_code,
+    filter_code_whole,
+)
 
 def can_be_solution(
     msg: str, min_lines: int, check_func=None, check_string=None, unittests=None

--- a/lang.py
+++ b/lang.py
@@ -6,6 +6,7 @@ from scoring import (
     verifier_feedback,
     filter_code,
     filter_code_whole,
+    run_unittests,
 )
 
 def can_be_solution(

--- a/python.py
+++ b/python.py
@@ -23,9 +23,26 @@ def find_first_index(string, char1, char2):
     else:
         return min(index1, index2)  # Return the minimum index
 
+# If the last line is not return, we should keep generating code
+def code_missing_return(v):
+    reverse_lines = v.splitlines()[::-1]
+    for line in reverse_lines:
+        line = line.strip()
+        if line.startswith('return'):
+            print('code has return')
+            return False
+        elif line == "":
+            continue
+        elif line.startswith('#'):
+            continue
+        else:
+            print('code missing return', line)
+            return True
+    print('only whitespace or comments')
+    return True # we only have whitespace or comments
+
 def calculate_code_score_with_err(v: str, code_maybe_incomplete: Callable[[int],bool]) -> (Optional[float], Optional[str]):
-    # If the last line is not return, we should keep generating code
-    if v == "" or (not v.splitlines()[-1].strip().startswith('return')): 
+    if code_missing_return(v):
         return None, None
     v = v.strip()
     r = check_code(v)

--- a/python.py
+++ b/python.py
@@ -2,22 +2,10 @@ from execute import execute, livecode
 import requests
 import re
 from typing import Optional
+from collections.abc import Callable
 
-def verifier_feedback(ok: str, not_ok: str) -> Optional[str]:
-    msg = "Consider previous issue"
-    if msg in ok:
-        return None
-    _, err = calculateScoreHelper(not_ok)
-    if err:
-        err = err.strip()
-        hint = f"\n # {msg}: {err}\n"
-        text = ok + hint
-        return text
-    return None
-
-def calculateScore(msg: str) -> Optional[float]:
-    score, _ = calculateScoreHelper(msg)
-    return score
+def create_comment(msg: str) -> str:
+    return f"'''\n{msg}\n'''"
 
 def find_first_index(string, char1, char2):
     try:
@@ -35,8 +23,7 @@ def find_first_index(string, char1, char2):
     else:
         return min(index1, index2)  # Return the minimum index
 
-def calculateScoreHelper(msg: str) -> (Optional[float], Optional[str]):
-    v = filter_code(msg + "```")
+def calculate_code_score_with_err(v: str, code_maybe_incomplete: Callable[[int],bool]) -> (Optional[float], Optional[str]):
     # If the last line is not return, we should keep generating code
     if v == "" or (not v.splitlines()[-1].strip().startswith('return')): 
         return None, None
@@ -49,32 +36,12 @@ def calculateScoreHelper(msg: str) -> (Optional[float], Optional[str]):
     marker = "ex.py\", line "
     first = log[log.rindex(marker) + len(marker):]
     num_line_first = int(first[0 : find_first_index(first, '\n', ',')])
-    if filter_code(msg).strip() != v and num_line_first >= v.count("\n"):
+    if code_maybe_incomplete(num_line_first):
         return None, None
     err = log
     return -1.0, err
 
-def runUnittests(msg: str) -> (Optional[float], Optional[str]):
-    v = filter_code(msg + "```").strip()
-    if v == "":
-        return None, None
-    r = check_code(v)
-    if r["status"] == 0:
-        return 1.0, None
-    log = r["log"]
-    print(log)
-    marker = "ex.py\", line "
-    first = log[log.rindex(marker) + len(marker):]
-    num_line_first = int(first[0 : find_first_index(first, '\n', ',')])
-    if filter_code(msg).strip() != v and num_line_first >= v.count("\n"):
-        return None, None
-    err = log
-    return -1.0, err
-
-def filter_code(msg: str) -> str:
-    m = re.findall("```([Pp]ython)?(.*?)```", msg, re.MULTILINE | re.DOTALL)
-    r = "\n".join([x[1] for x in m])
-    return r
+re_code_lang = "```([Pp]ython)?(.*?)```"
 
 def check_code(v: str) -> dict:
     return execute("python3", "py", v, use_sandbox=True)
@@ -95,8 +62,7 @@ def finalReport():
 		print('TRUE')
 		sys.exit(0)
 """
-def run_unittests(msg: str, unittest=None):
-    v = filter_code(msg + "```").strip()
+def run_unittests(v: str, unittest=None):
     file = v
     file += test_fwk
     foundAll = True
@@ -108,28 +74,4 @@ def run_unittests(msg: str, unittest=None):
     file += "\nfinalReport()\n"
     print(file)
     return check_code(file)["status"]
-
-def score_func(sentence: str, unittest: Optional[str] = None) -> Optional[float]:
-    print("TEXT")
-    print(sentence)
-    score = calculateScore(sentence)
-    if unittest is None or score != 1:
-        print("SCORE")
-        print(score)
-        return score
-    else:
-        print("Preliminary SCORE")
-        print(score)
-        tscore = run_unittests(sentence, unittest)
-        if tscore != 0:
-            print("Unittest tscore ", tscore, "FAILED. Lowering score.")
-            print("NEW SCORE")
-            print("-1")
-            return -1
-        else:
-            print("Unittest succeeded, tscore = ", tscore, "and score remains", score)
-            return score
-
-score_func_whole = score_func
-filter_code_whole = filter_code
 

--- a/rust.py
+++ b/rust.py
@@ -2,25 +2,12 @@ from execute import execute, livecode
 import requests
 import re
 from typing import Optional
+from collections.abc import Callable
 
-def verifier_feedback(ok: str, not_ok: str) -> Optional[str]:
-    msg = "Consider previous issue"
-    if msg in ok:
-        return None
-    _, err = calculateScoreHelper(not_ok)
-    if err:
-        err = err.strip()
-        hint = f"\n/* {msg}: {err} */\n"
-        text = ok + hint
-        return text
-    return None
+def create_comment(msg: str) -> str:
+    return f"/* {msg} */"
 
-def calculateScore(msg: str) -> Optional[float]:
-    score, _ = calculateScoreHelper(msg)
-    return score
-
-def calculateScoreHelper(msg: str) -> (Optional[float], Optional[str]):
-    v = filter_code(msg + "```").strip()
+def calculate_code_score_with_err(v: str, code_maybe_incomplete: Callable[[int],bool]) -> (Optional[float], Optional[str]):
     if v == "":
         return None, None
     r = check_code(v)
@@ -30,24 +17,13 @@ def calculateScoreHelper(msg: str) -> (Optional[float], Optional[str]):
     print(log)
     first = log[log.rindex("ex.rs:") + 6 :]
     num_line_first = int(first[0 : first.index(":")])
-    if filter_code(msg).strip() != v and num_line_first >= v.count("\n"):
+    if code_maybe_incomplete(num_line_first):
         return None, None
     else:
         err = log
         return -1.0, err
 
-def score_func(sentence: str) -> Optional[float]:
-    print("TEXT")
-    print(sentence)
-    score = calculateScore(sentence)
-    print("SCORE")
-    print(score)
-    return score
-
-def filter_code(msg: str) -> str:
-    m = re.findall("```([Rr]ust)?(.*?)```", msg, re.MULTILINE | re.DOTALL)
-    r = "\n".join([x[1] for x in m])
-    return r
+re_code_lang = "```([Rr]ust)?(.*?)```"
 
 def check_code(v: str) -> dict:
     return execute("rustc --crate-type lib", "rs", v)

--- a/scoring.py
+++ b/scoring.py
@@ -21,10 +21,10 @@ elif LANG == "Coq":
     )
 elif LANG == "Lean4":
     from lean import (
-        score_func,
-        verifier_feedback,
-        filter_code,
+        create_comment,
+        calculate_code_score_with_err,
         check_code,
+        re_code_lang,
     )
 elif LANG == "Rust":
     from rust import (

--- a/scoring.py
+++ b/scoring.py
@@ -1,0 +1,144 @@
+from lang_config import LANG
+import re
+from typing import Optional, Tuple, List
+
+run_tests = False
+if LANG == "Dafny":
+    from dafny import (
+        create_comment,
+        calculate_code_score_with_err,
+        check_code,
+        re_code_lang
+    )
+elif LANG == "Coq":
+    from coq import (
+        score_func,
+        score_func_whole,
+        verifier_feedback,
+        short_verifier_feedback,
+        filter_code,
+        filter_code_whole,
+        check_code,
+    )
+elif LANG == "Lean4":
+    from lean import (
+        score_func,
+        verifier_feedback,
+        filter_code,
+        check_code,
+    )
+elif LANG == "Rust":
+    from rust import (
+        score_func,
+        verifier_feedback,
+        filter_code,
+        check_code,
+    )
+elif LANG == "Scala":
+    from scala import (
+        score_func,
+        verifier_feedback,
+        filter_code,
+        check_code,
+    )
+elif LANG == "Python":
+    from python import (
+        score_func,
+        score_func_whole,
+        verifier_feedback,
+        filter_code,
+        filter_code_whole,
+        check_code,
+        run_unittests,
+    )
+    run_tests = True
+else:
+    assert False
+
+def findall_code(msg, re_code):
+    m = re.findall(re_code, msg, re.MULTILINE | re.DOTALL)
+    return [x[1] for x in m]
+
+def filter_code(msg: str) -> str:
+    r = "\n".join(findall_code(msg, re_code_lang))
+    return r
+
+def make_code_is_incomplete(msg, v):
+    return
+
+def calculate_score_with_err(msg: str) -> (Optional[float], Optional[str]):
+    v = filter_code(msg + "```").strip()
+    code_maybe_incomplete = lambda num_line_first: filter_code(msg).strip() != v and num_line_first >= v.count("\n")
+    return calculate_code_score_with_err(v, code_maybe_incomplete)
+
+def calculate_score(msg: str) -> Optional[float]:
+    score, _ = calculate_score_with_err(msg)
+    return score
+
+def short_verifier_feedback(ok: str, not_ok: str) -> Optional[Tuple[str,str]]:
+    _, err = calculate_score_with_err(not_ok)
+    if err:
+        err = err.strip()
+        return (None, err)
+    return None
+
+def create_hint(msg: str, err: str) -> str:
+    return create_comment(f"{msg}: {err}")
+
+def verifier_feedback(ok: str, not_ok: str) -> Optional[str]:
+    msg = "Consider previous issue"
+    if msg in ok:
+        return None
+    _, err = calculate_score_with_err(not_ok)
+    if err:
+        err = err.strip()
+        hint = create_hint(msg, err)
+        text = ok + hint
+        return text
+    return None
+
+def score_func(sentence: str) -> Optional[float]:
+    print("TEXT")
+    print(sentence)
+    score = calculate_score(sentence)
+    print("SCORE")
+    print(score)
+    return score
+
+### Functions to work specifically with text output from run_whole.py
+
+def filter_code_whole(msg: str) -> list[str]:
+    return findall_code(msg, re_code_lang)
+
+def calculate_score_with_err_whole(msg: str) -> (Optional[float], Optional[str]):
+    vs = [s.strip() for s in filter_code_whole(msg + "```")]
+    for v in vs:
+        score, score_err = calcuate_code_score(v)
+        if score is not None and score > 0.5:
+            return score, score_err
+    err = ""
+    return -1.0, err
+
+def calculate_score_whole(msg: str) -> Optional[float]:
+    score_whole, _ = calculate_score_with_err_whole(msg)
+    score, _ = calculate_score_with_err(msg)
+    print("SCORE")
+    print(score)
+    print("SCORE_WHOLE")
+    print(score_whole)
+    # always return the better of the two scores
+    if score_whole:
+        if score_whole == 1.0:
+            return 1.0
+        if score is None:
+            return score_whole
+        return score
+    return score
+
+def score_func_whole(sentence: str) -> Optional[float]:
+    print("TEXT")
+    print(sentence)
+    score = calculate_score_whole(sentence)
+    print("SCORE_FINAL")
+    print(score)
+    return score

--- a/scoring.py
+++ b/scoring.py
@@ -35,10 +35,10 @@ elif LANG == "Rust":
     )
 elif LANG == "Scala":
     from scala import (
-        score_func,
-        verifier_feedback,
-        filter_code,
+        create_comment,
+        calculate_code_score_with_err,
         check_code,
+        re_code_lang,
     )
 elif LANG == "Python":
     from python import (

--- a/scoring.py
+++ b/scoring.py
@@ -28,10 +28,10 @@ elif LANG == "Lean4":
     )
 elif LANG == "Rust":
     from rust import (
-        score_func,
-        verifier_feedback,
-        filter_code,
+        create_comment,
+        calculate_code_score_with_err,
         check_code,
+        re_code_lang,
     )
 elif LANG == "Scala":
     from scala import (

--- a/scoring.py
+++ b/scoring.py
@@ -110,10 +110,13 @@ def score_func(sentence: str) -> Optional[float]:
 def filter_code_whole(msg: str) -> list[str]:
     return findall_code(msg, re_code_lang)
 
+def code_is_complete(x):
+    return False # code_maybe_incomplete is False
+
 def calculate_score_with_err_whole(msg: str) -> (Optional[float], Optional[str]):
     vs = [s.strip() for s in filter_code_whole(msg + "```")]
     for v in vs:
-        score, score_err = calcuate_code_score(v)
+        score, score_err = calculate_code_score_with_err(v, code_is_complete)
         if score is not None and score > 0.5:
             return score, score_err
     err = ""


### PR DESCRIPTION
This PR has more deletions than additions, and unlock common evaluation features such as scoring, scoring whole, verifier feedback, and unittest scaffolding.

Also fixes missing return detection in Python. This could be backported.

In passing uses underscores instead of camel case for names.

@ChloeL19 for whole scoring evaluation logic.

@shenniger for review.



